### PR TITLE
Adding an example of using the RabbitMQ Transport

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,6 +14,8 @@
     <PackageVersion Include="Ardalis.Result" Version="10.1.0" />
     <PackageVersion Include="Ardalis.Specification" Version="9.2.0" />
     <PackageVersion Include="Ardalis.Specification.EntityFrameworkCore" Version="9.2.0" />
+    <PackageVersion Include="Aspire.Hosting.RabbitMQ" Version="9.3.1" />
+    <PackageVersion Include="Aspire.RabbitMQ.Client" Version="9.3.1" />
     <PackageVersion Include="AspNetCore.Security.OAuth.Extensions" Version="1.0.0" />
     <PackageVersion Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.4.0" />
     <PackageVersion Include="Azure.Identity" Version="1.14.0" />
@@ -52,6 +54,7 @@
     <PackageVersion Include="NServiceBus" Version="9.2.7" />
     <PackageVersion Include="NServiceBus.Extensions.Hosting" Version="3.0.1" />
     <PackageVersion Include="NimblePros.Metronome" Version="0.4.1" />
+    <PackageVersion Include="NServiceBus.RabbitMQ" Version="10.1.3" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="NSubstitute.Analyzers.CSharp" Version="1.0.17" />
     <PackageVersion Include="System.Diagnostics.Debug" Version="4.3.0" />
@@ -69,9 +72,9 @@
     <PackageVersion Include="System.Threading" Version="4.3.0" />
     <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.12.0" />
     <!-- Aspire -->
-    <PackageVersion Include="Aspire.Hosting.Seq" Version="9.1.0" />
-    <PackageVersion Include="Aspire.Seq" Version="9.1.0" />
-    <PackageVersion Include="Aspire.Hosting.AppHost" Version="9.1.0" />
+    <PackageVersion Include="Aspire.Hosting.Seq" Version="9.3.1" />
+    <PackageVersion Include="Aspire.Seq" Version="9.3.1" />
+    <PackageVersion Include="Aspire.Hosting.AppHost" Version="9.3.1" />
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="9.1.0" />
     <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="9.1.0" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.12.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,6 +14,7 @@
     <PackageVersion Include="Ardalis.Result" Version="10.1.0" />
     <PackageVersion Include="Ardalis.Specification" Version="9.2.0" />
     <PackageVersion Include="Ardalis.Specification.EntityFrameworkCore" Version="9.2.0" />
+    <PackageVersion Include="Aspire.Hosting.Python" Version="9.3.1" />
     <PackageVersion Include="Aspire.Hosting.RabbitMQ" Version="9.3.1" />
     <PackageVersion Include="Aspire.RabbitMQ.Client" Version="9.3.1" />
     <PackageVersion Include="AspNetCore.Security.OAuth.Extensions" Version="1.0.0" />

--- a/python/isolated-to-python/README.md
+++ b/python/isolated-to-python/README.md
@@ -1,0 +1,17 @@
+# Python RabbitMQ Demo - Isolated to Python
+
+For this demo, we have RabbitMQ set up via .NET Aspire:
+
+```csharp
+
+var rabbitUser = builder.AddParameter("rabbitUser", "rabbitUser");
+var rabbitPassword = builder.AddParameter("rabbitPassword", "rabbitPassword");
+var rabbitmq = builder.AddRabbitMQ("messaging", rabbitUser, rabbitPassword,5672)
+.WithManagementPlugin();
+```
+
+The **python-rabbitmq-receive.py** can be used to receive test messages from a queue called `hello`.
+- This script can be stopped with <kbd>Ctrl+C</kbd>.
+
+The **python-rabbitmq-send.py** can be used to send test messages to a queue called `hello`. 
+- Execute this in another Python prompt to show how you can send and the receive script will pick up what's sent as it's sent.

--- a/python/isolated-to-python/python-rabbitmq-receive.py
+++ b/python/isolated-to-python/python-rabbitmq-receive.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env 
+# pip3 install pika
+# pip install pika
+import pika, sys, os
+
+RABBITMQ_HOST = 'localhost'
+RABBITMQ_PORT = 5672
+
+RABBITMQ_USERNAME = 'rabbitUser'
+RABBITMQ_PASSWORD = 'rabbitPassword'
+
+def main():
+    credentials = pika.PlainCredentials(username=RABBITMQ_USERNAME, password=RABBITMQ_PASSWORD)
+    connection = pika.BlockingConnection(pika.ConnectionParameters(host=RABBITMQ_HOST, port=RABBITMQ_PORT, credentials=credentials))
+    channel = connection.channel()
+
+    channel.queue_declare(queue='hello')
+
+    def callback(ch, method, properties, body):
+        print(f" [x] Received {body}")
+
+    channel.basic_consume(queue='hello', on_message_callback=callback, auto_ack=True)
+
+    print(' [*] Waiting for messages. To exit press CTRL+C')
+    channel.start_consuming()
+
+if __name__ == '__main__':
+    try:
+        main()
+    except KeyboardInterrupt:
+        print('Interrupted')
+        try:
+            sys.exit(0)
+        except SystemExit:
+            os._exit(0)

--- a/python/isolated-to-python/python-rabbitmq-send.py
+++ b/python/isolated-to-python/python-rabbitmq-send.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python
+import pika
+
+RABBITMQ_HOST = 'localhost'
+RABBITMQ_PORT = 5672
+
+RABBITMQ_USERNAME = 'rabbitUser'
+RABBITMQ_PASSWORD = 'rabbitPassword'
+
+credentials = pika.PlainCredentials(username=RABBITMQ_USERNAME, password=RABBITMQ_PASSWORD)
+
+
+connection = pika.BlockingConnection(
+    pika.ConnectionParameters(host=RABBITMQ_HOST,port=RABBITMQ_PORT, credentials=credentials))
+channel = connection.channel()
+
+channel.queue_declare(queue='hello')
+
+channel.basic_publish(exchange='', routing_key='hello', body='Hello World!')
+print(" [x] Sent 'Hello World!'")
+connection.close()

--- a/python/with-nservicebus-demo/README.md
+++ b/python/with-nservicebus-demo/README.md
@@ -1,0 +1,13 @@
+# Python RabbitMQ working with NServiceBus
+
+In this demo, we are using NServiceBus with the [RabbitMQ Transport](https://docs.particular.net/transports/rabbitmq/).
+
+For this demo, we have RabbitMQ set up via .NET Aspire:
+
+```csharp
+
+var rabbitUser = builder.AddParameter("rabbitUser", "rabbitUser");
+var rabbitPassword = builder.AddParameter("rabbitPassword", "rabbitPassword");
+var rabbitmq = builder.AddRabbitMQ("messaging", rabbitUser, rabbitPassword,5672)
+.WithManagementPlugin();
+```

--- a/python/with-nservicebus-demo/python-rabbitmq-combined.py
+++ b/python/with-nservicebus-demo/python-rabbitmq-combined.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env 
+# pip3 install pika
+# pip install pika
+import pika, sys, os
+
+RABBITMQ_HOST = 'localhost'
+RABBITMQ_PORT = 5672
+
+RABBITMQ_USERNAME = 'rabbitUser'
+RABBITMQ_PASSWORD = 'rabbitPassword'
+
+def main():
+    credentials = pika.PlainCredentials(username=RABBITMQ_USERNAME, password=RABBITMQ_PASSWORD)
+    connection = pika.BlockingConnection(pika.ConnectionParameters(host=RABBITMQ_HOST, port=RABBITMQ_PORT, credentials=credentials))
+    channel = connection.channel()
+
+    channel.queue_declare(queue='orders',durable=True,arguments={"x-queue-type": "quorum"})
+    channel.queue_declare(queue='payments',durable=True,arguments={"x-queue-type": "quorum"})
+
+    def callback(ch, method, properties, body):
+        print(f" [x] Received {body}")
+        channel.basic_publish(exchange='', routing_key='payments', body='Payment Processed')
+        print(" [x] Sent 'Payment Processed'")
+
+
+    channel.basic_consume(queue='orders', on_message_callback=callback, auto_ack=True)
+
+    print(' [*] Waiting for messages. To exit press CTRL+C')
+    channel.start_consuming()
+
+if __name__ == '__main__':
+    try:
+        main()
+    except KeyboardInterrupt:
+        print('Interrupted')
+        try:
+            sys.exit(0)
+        except SystemExit:
+            os._exit(0)

--- a/python/with-nservicebus-demo/python-rabbitmq-receive.py
+++ b/python/with-nservicebus-demo/python-rabbitmq-receive.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env 
+# pip3 install pika
+# pip install pika
+import pika, sys, os
+
+RABBITMQ_HOST = 'localhost'
+RABBITMQ_PORT = 5672
+
+RABBITMQ_USERNAME = 'rabbitUser'
+RABBITMQ_PASSWORD = 'rabbitPassword'
+
+def main():
+    credentials = pika.PlainCredentials(username=RABBITMQ_USERNAME, password=RABBITMQ_PASSWORD)
+    connection = pika.BlockingConnection(pika.ConnectionParameters(host=RABBITMQ_HOST, port=RABBITMQ_PORT, credentials=credentials))
+    channel = connection.channel()
+
+    channel.queue_declare(queue='orders-worker')
+
+    def callback(ch, method, properties, body):
+        print(f" [x] Received {body}")
+
+    channel.basic_consume(queue='orders-worker', on_message_callback=callback, auto_ack=True)
+
+    print(' [*] Waiting for messages. To exit press CTRL+C')
+    channel.start_consuming()
+
+if __name__ == '__main__':
+    try:
+        main()
+    except KeyboardInterrupt:
+        print('Interrupted')
+        try:
+            sys.exit(0)
+        except SystemExit:
+            os._exit(0)

--- a/python/with-nservicebus-demo/python-rabbitmq-receive.py
+++ b/python/with-nservicebus-demo/python-rabbitmq-receive.py
@@ -14,7 +14,7 @@ def main():
     connection = pika.BlockingConnection(pika.ConnectionParameters(host=RABBITMQ_HOST, port=RABBITMQ_PORT, credentials=credentials))
     channel = connection.channel()
 
-    channel.queue_declare(queue='orders-worker')
+    channel.queue_declare(queue='orders-worker',durable=True,arguments={"x-queue-type": "quorum"})
 
     def callback(ch, method, properties, body):
         print(f" [x] Received {body}")

--- a/python/with-nservicebus-demo/python-rabbitmq-send.py
+++ b/python/with-nservicebus-demo/python-rabbitmq-send.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python
+import pika
+
+RABBITMQ_HOST = 'localhost'
+RABBITMQ_PORT = 5672
+
+RABBITMQ_USERNAME = 'rabbitUser'
+RABBITMQ_PASSWORD = 'rabbitPassword'
+
+credentials = pika.PlainCredentials(username=RABBITMQ_USERNAME, password=RABBITMQ_PASSWORD)
+
+
+connection = pika.BlockingConnection(
+    pika.ConnectionParameters(host=RABBITMQ_HOST,port=RABBITMQ_PORT, credentials=credentials))
+channel = connection.channel()
+
+channel.queue_declare(queue='payments',durable=True,arguments={"x-queue-type": "quorum"})
+
+channel.basic_publish(exchange='', routing_key='payments', body='Payment Processed')
+print(" [x] Sent 'Payment Processed'")
+connection.close()

--- a/src/ApplicationCore/ApplicationCore.csproj
+++ b/src/ApplicationCore/ApplicationCore.csproj
@@ -10,6 +10,7 @@
 		<PackageReference Include="Ardalis.Result" />
     <PackageReference Include="Ardalis.Specification" />
     <PackageReference Include="NServiceBus" />
+    <PackageReference Include="NServiceBus.RabbitMQ" />
 		<PackageReference Include="System.Security.Claims" />
 		<PackageReference Include="System.Text.Json" />
 	</ItemGroup>

--- a/src/ApplicationCore/Configuration/NServiceBusConfiguration.cs
+++ b/src/ApplicationCore/Configuration/NServiceBusConfiguration.cs
@@ -7,10 +7,18 @@ public static class NServiceBusConfiguration
     public static EndpointConfiguration GetNServiceBusConfiguration()
     {
         var endpointConfiguration = new EndpointConfiguration("orders-worker");
+
         endpointConfiguration.UseSerialization<SystemJsonSerializer>();
 
-        var transport = endpointConfiguration.UseTransport<LearningTransport>();
-
+        // This is DEMO code
+        // Normally, I wouldn't recommend disabling the remote certificate validation
+        // However, we're running locally
+        // Also, the connection string could be tied in via DI
+        var transport = endpointConfiguration.UseTransport<RabbitMQTransport>();
+        transport.ConnectionString("amqp://rabbitUser:rabbitPassword@localhost:5672");
+        transport.UseConventionalRoutingTopology(QueueType.Quorum);
+        transport.DisableRemoteCertificateValidation();
+        
         transport.Routing().RouteToEndpoint(
           typeof(OrderCreatedEvent),
           "orders-worker");

--- a/src/ApplicationCore/Configuration/NServiceBusConfiguration.cs
+++ b/src/ApplicationCore/Configuration/NServiceBusConfiguration.cs
@@ -16,7 +16,8 @@ public static class NServiceBusConfiguration
         // Also, the connection string could be tied in via DI
         var transport = endpointConfiguration.UseTransport<RabbitMQTransport>();
         transport.ConnectionString("amqp://rabbitUser:rabbitPassword@localhost:5672");
-        transport.UseConventionalRoutingTopology(QueueType.Quorum);
+        // We're using Direct routing to run on a single exchange
+        transport.UseDirectRoutingTopology(QueueType.Quorum);
         transport.DisableRemoteCertificateValidation();
         
         transport.Routing().RouteToEndpoint(

--- a/src/eShopOnWeb.Worker/Program.cs
+++ b/src/eShopOnWeb.Worker/Program.cs
@@ -1,11 +1,14 @@
 ﻿using System.Text.Json;
+using Microsoft.AspNetCore.Server.Kestrel;
 using Microsoft.eShopWeb.ApplicationCore.Configuration;
 using NServiceBus;
+using NServiceBus.Installation;
 
 var builder = Host.CreateDefaultBuilder();
 
 builder.UseConsoleLifetime();
 builder.UseNServiceBus(context => NServiceBusConfiguration.GetNServiceBusConfiguration());
+await Installer.Setup(NServiceBusConfiguration.GetNServiceBusConfiguration());
 
 var host = builder.Build();
 

--- a/src/eShopOnWeb.Worker/Program.cs
+++ b/src/eShopOnWeb.Worker/Program.cs
@@ -8,4 +8,5 @@ builder.UseConsoleLifetime();
 builder.UseNServiceBus(context => NServiceBusConfiguration.GetNServiceBusConfiguration());
 
 var host = builder.Build();
+
 host.Run();

--- a/src/eShopOnWeb.Worker/eShopOnWeb.Worker.csproj
+++ b/src/eShopOnWeb.Worker/eShopOnWeb.Worker.csproj
@@ -10,6 +10,7 @@
   <ItemGroup>
     <PackageReference Include="NServiceBus" />
     <PackageReference Include="NServiceBus.Extensions.Hosting" />
+    <PackageReference Include="NServiceBus.RabbitMQ" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/eShopWeb.AppHost/Program.cs
+++ b/src/eShopWeb.AppHost/Program.cs
@@ -1,3 +1,5 @@
+﻿using Microsoft.Extensions.Hosting;
+
 var builder = DistributedApplication.CreateBuilder(args);
 
 var seq = builder.AddSeq("seq")
@@ -9,11 +11,17 @@ builder
         .WithReference(seq)
         .WaitFor(seq);
 
+var rabbitUser = builder.AddParameter("rabbitUser", "rabbitUser");
+var rabbitPassword = builder.AddParameter("rabbitPassword", "rabbitPassword");
+var rabbitmq = builder.AddRabbitMQ("messaging", rabbitUser, rabbitPassword, 5672)
+                      .WithManagementPlugin(port: 15672);
+builder.AddProject<Projects.eShopOnWeb_Worker>("eshoponweb-worker")
+    .WaitFor(rabbitmq);
+
 builder
     .AddProject<Projects.Web>(nameof(Projects.Web).ToLower())
         .WithReference(seq)
-        .WaitFor(seq);
-
-builder.AddProject<Projects.eShopOnWeb_Worker>("eshoponweb-worker");
+        .WaitFor(seq)
+        .WaitFor(rabbitmq);
 
 builder.Build().Run();

--- a/src/eShopWeb.AppHost/Program.cs
+++ b/src/eShopWeb.AppHost/Program.cs
@@ -23,5 +23,8 @@ builder
         .WithReference(seq)
         .WaitFor(seq)
         .WaitFor(rabbitmq);
+#pragma warning disable
+builder.AddPythonApp("python-queue-listener", "../../", "./python/with-nservicebus-demo/python-rabbitmq-combined.py")
+    .WaitFor(rabbitmq);
 
 builder.Build().Run();

--- a/src/eShopWeb.AppHost/eShopWeb.AppHost.csproj
+++ b/src/eShopWeb.AppHost/eShopWeb.AppHost.csproj
@@ -1,5 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Sdk Name="Aspire.AppHost.Sdk" Version="9.0.0" />
+  <Sdk Name="Aspire.AppHost.Sdk" Version="9.3.1" />
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net9.0</TargetFramework>
@@ -11,6 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="Aspire.Hosting.AppHost" />
+    <PackageReference Include="Aspire.Hosting.Python" />
     <PackageReference Include="Aspire.Hosting.RabbitMQ" />
     <PackageReference Include="Aspire.Hosting.Seq" />
     <PackageReference Include="Aspire.RabbitMQ.Client" />

--- a/src/eShopWeb.AppHost/eShopWeb.AppHost.csproj
+++ b/src/eShopWeb.AppHost/eShopWeb.AppHost.csproj
@@ -11,7 +11,9 @@
 
   <ItemGroup>
     <PackageReference Include="Aspire.Hosting.AppHost" />
+    <PackageReference Include="Aspire.Hosting.RabbitMQ" />
     <PackageReference Include="Aspire.Hosting.Seq" />
+    <PackageReference Include="Aspire.RabbitMQ.Client" />
     <PackageReference Include="NimblePros.Metronome" />
   </ItemGroup>
 


### PR DESCRIPTION
- Demo of .NET Producer, Python consumer - as seen in the July webinar